### PR TITLE
Feat/#94 Results per page of search hit results list.

### DIFF
--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -142,7 +142,6 @@ export default {
     maxRecord() {
       const limit = (this.page - 1) * this.maxResultsSize + this.maxResultsSize;
 
-      console.log("temp", this.total, limit, this.page, this.maxResultsSize);
       if (this.total < limit) {
         return this.total;
       }
@@ -248,7 +247,6 @@ export default {
         })
         .catch((error) => {
           this.error = true;
-          console.log(error);
         })
         .finally(() => {
           this.loading = false;

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -47,8 +47,19 @@
           </div>
 
           <div class="flex items-center justify-between col-span-4">
+            <div>
+              Items per Page:
+              <select
+                v-model="maxResultsSize"
+                @change="handlePageSizeChange($event)"
+              >
+                <option v-for="size in pageSizes" :key="size" :value="size">
+                  {{ size }}
+                </option>
+              </select>
+            </div>
             <p>
-              Showing {{ (this.page - 1) * this.perPageData + 1 }} -
+              Showing {{ (this.page - 1) * this.maxResultsSize + 1 }} -
               {{ maxRecord }} of {{ total }} hits
             </p>
             <div class="space-x-3">
@@ -108,14 +119,17 @@ export default {
     return {
       loading: true,
       error: null,
-      maxResultsSize: 10,
       paginationLowerBound: 1,
       scrolls: [""],
       time: 0,
       results: null,
+      pageSizes: [10, 20, 30],
     };
   },
   computed: {
+    maxResultsSize() {
+      return Number(this.$route.query.perPageRecords || 10);
+    },
     data() {
       if (!this.results) {
         return [];
@@ -126,14 +140,16 @@ export default {
       return this.results.hits;
     },
     maxRecord() {
-      const limit = (this.page - 1) * this.perPageData + this.perPageData;
+      const limit = (this.page - 1) * this.maxResultsSize + this.maxResultsSize;
+
+      console.log("temp", this.total, limit, this.page, this.maxResultsSize);
       if (this.total < limit) {
         return this.total;
       }
       return limit;
     },
     pagintation() {
-      const count = Math.ceil(this.total / this.perPageData);
+      const count = Math.ceil(this.total / this.maxResultsSize);
       const current = this.page;
       var shownPages = 3;
       var result = [];
@@ -143,9 +159,6 @@ export default {
         result.push(current, current + 1, current + 2);
       }
       return result;
-    },
-    perPageData() {
-      return 10;
     },
     hasResult() {
       return this.results;
@@ -164,7 +177,8 @@ export default {
     },
     isLastPage() {
       return (
-        (this.page - 1) * this.perPageData + this.perPageData >= this.total
+        (this.page - 1) * this.maxResultsSize + this.maxResultsSize >=
+        this.total
       );
     },
   },
@@ -182,7 +196,7 @@ export default {
       this.$router.push({
         name: "search",
         query: {
-          q: this.query,
+          ...this.$route.query,
           page,
         },
       });
@@ -191,7 +205,7 @@ export default {
       this.$router.push({
         name: "search",
         query: {
-          q: this.query,
+          ...this.$route.query,
           page: this.page - 1,
         },
       });
@@ -200,8 +214,17 @@ export default {
       this.$router.push({
         name: "search",
         query: {
-          q: this.query,
+          ...this.$route.query,
           page: this.page + 1,
+        },
+      });
+    },
+    handlePageSizeChange(event) {
+      this.$router.push({
+        name: "search",
+        query: {
+          ...this.$route.query,
+          perPageRecords: event.target.value,
         },
       });
     },
@@ -216,8 +239,8 @@ export default {
       lzaApi
         .search(
           this.query,
-          (this.page - 1) * this.perPageData,
-          this.perPageData
+          (this.page - 1) * this.maxResultsSize,
+          this.maxResultsSize
         )
         .then((response) => {
           // Render the results


### PR DESCRIPTION
- change the baseUrl in services/lzaApi.ts file line 4 - `baseURL: 'http://141.5.99.53/api',` and run the app using the command - `yarn serve`.
- search an example term - `Berlin` and once we get the search hit list, we notice `Item Per Page: 10`. It's a select menu where user is allowed to change number of items per page (Default: 10, can be changed to. 20, 30). 
- Once change, the results page loads with new number of  of items. We can also navigate to other page as well.